### PR TITLE
Fixed left/right after climbing bug

### DIFF
--- a/objects/obj_ball/Create_0.gml
+++ b/objects/obj_ball/Create_0.gml
@@ -8,7 +8,7 @@ arc = false; //whether or not ball will arc
 alarm[0] = 6*30 //destroy the ball after 6 seconds
 
 //Physics
-mass = 10;
+mass = 12;
 
 ///Animations
 ps_spark = noone

--- a/objects/obj_character/Step_0.gml
+++ b/objects/obj_character/Step_0.gml
@@ -35,6 +35,7 @@ if (active) {
         case 1:
             // local input
             if(Input_player.inputs[LEFT_KEY]) haxis1 = -1;
+			if haxis1 = -1 show_debug_message("Left pressed")
             if(Input_player.inputs[RIGHT_KEY]) haxis1 = 1;
             if(Input_player.inputs[UP_KEY] == KEY_PRESSED) vaxis1 = -1;
             if(Input_player.inputs[DOWN_KEY] == KEY_PRESSED) vaxis1 = 1;
@@ -95,26 +96,24 @@ if (active) {
 	if not place_free(x, y + 1){
 		//Move if joystick is pushed far enough
 	    if !(haxis1 > -axis_buffer and haxis1 < axis_buffer and vaxis1 > -axis_buffer and vaxis1 < axis_buffer) {
-			if (!left_action_is_pressed and !right_action_is_pressed) or has_jetpack{
-				//down key to inch sideways
-				if down_pressed > axis_buffer{
-					if place_free(x + haxis1, y + vspeed){
-						hspeed = 0
-						x += haxis1
-					}
+			//down key to inch sideways
+			if down_pressed > axis_buffer{
+				if place_free(x + haxis1, y + vspeed){
+					hspeed = 0
+					x += haxis1
+				}
+			}
+				
+				
+			else{
+				//accelerate
+				if abs(hspeed) < moveSpeed{
+					hspeed += haxis1*acceleration
 				}
 				
-				
+				//move once fully accelerated
 				else{
-					//accelerate
-					if abs(hspeed) < moveSpeed{
-						hspeed += haxis1*acceleration
-					}
-				
-					//move once fully accelerated
-					else{
-						hspeed = haxis1*moveSpeed
-					}
+					hspeed = haxis1*moveSpeed
 				}
 			}
 	        //Find direction player is facing
@@ -143,28 +142,26 @@ if (active) {
 	//If in the air
 	else{
 		if !(haxis1 > -axis_buffer and haxis1 < axis_buffer and vaxis1 > -axis_buffer and vaxis1 < axis_buffer) {
-	        if (!left_action_is_pressed and !right_action_is_pressed) or has_jetpack{
-				//If moving from a stop in air
-				if hspeed == 0{
-					hspeed += haxis1 * drag
-				}
-					
-				//If going the same direction
-				if sign(hspeed) == sign(haxis1){
-					if abs(hspeed) < moveSpeed{
-						hspeed += sign(hspeed) * drag
-					}
-				}
-					
-				//If opposing direction
-				if sign(hspeed) != sign(haxis1){
-					hspeed = (abs(hspeed) - drag) * sign(hspeed)
-				}
-				
-				//Change player's direction
-				if hspeed != 0 dir = sign(hspeed)
-				else if input_method != CONTROLS_KEYBOARD dir = 0 //Keyboard controls use direction to show aim reticule
+			//If moving from a stop in air
+			if hspeed == 0{
+				hspeed += haxis1 * drag
 			}
+					
+			//If going the same direction
+			if sign(hspeed) == sign(haxis1){
+				if abs(hspeed) < moveSpeed{
+					hspeed += sign(hspeed) * drag
+				}
+			}
+					
+			//If opposing direction
+			if sign(hspeed) != sign(haxis1){
+				hspeed = (abs(hspeed) - drag) * sign(hspeed)
+			}
+				
+			//Change player's direction
+			if hspeed != 0 dir = sign(hspeed)
+			else if input_method != CONTROLS_KEYBOARD dir = 0 //Keyboard controls use direction to show aim reticule
 		}
 	}
 	

--- a/objects/obj_character/Step_0.gml
+++ b/objects/obj_character/Step_0.gml
@@ -221,7 +221,7 @@ if (active) {
 	if down_pressed > axis_buffer{
 		//Check if there is a block under the player's left side
 		var Inst = instance_position(x + 4, y + sprite_height + 1, par_block)
-		//Otherwise check if there is ablock under the player's right side
+		//Otherwise check if there is a block under the player's right side
 		if Inst == noone{
 			Inst = instance_position(x - 4 + sprite_width, y + sprite_height + 1, par_block)
 		}

--- a/scripts/macros/macros.gml
+++ b/scripts/macros/macros.gml
@@ -43,5 +43,5 @@
 #macro STATE_GAME 2
 #macro STATE_SCORE 3
 
-#macro GRAB_TOL 6 
-#macro PLAYER_TOL 3
+#macro GRAB_TOL 6   //maximum number of pixels away a player's hit box can be and still grab an object
+#macro PLAYER_TOL 3 //number of pixels on either side of the character sprite before the hit box

--- a/scripts/scr_attempt_climbing/scr_attempt_climbing.gml
+++ b/scripts/scr_attempt_climbing/scr_attempt_climbing.gml
@@ -15,8 +15,8 @@ if place_free(x, y + 16) and place_free(x, y + 32){
 						
 			//if the player is near the top allow them to hang onto the ledge
 			if (y + y_diff > other.y - hanging_tol) and (y + y_diff < other.y + hanging_tol){
-				//Must add player width when facing positive direction to exclude
-				if place_free(x + dir * 4, other.y - sprite_height){
+				//Must add block width when facing negative direction
+				if position_empty(other.x - min(dir*other.sprite_width, 0) + dir * 4, other.y - sprite_height){
 					scr_enter_hanging()
 				}
 			}

--- a/scripts/scr_attempt_climbing/scr_attempt_climbing.gml
+++ b/scripts/scr_attempt_climbing/scr_attempt_climbing.gml
@@ -14,9 +14,10 @@ if place_free(x, y + 16) and place_free(x, y + 32){
 			}
 						
 			//if the player is near the top allow them to hang onto the ledge
-			if (y + y_diff > other.y - hanging_tol) and (y + y_diff < other.y + hanging_tol){
-				//Must add block width when facing negative direction
-				if position_empty(other.x - min(dir*other.sprite_width, 0) + dir * 4, other.y - sprite_height){
+			if y + y_diff < other.y + hanging_tol{
+				//Must add block width when facing negative direction and subtract player width in the positive direction
+				if place_free(other.x - min(dir*other.sprite_width, 0) - max(dir*sprite_width, 0) + dir * 4, other.y - sprite_height)
+				or instance_position(other.x - min(dir*other.sprite_width, 0) + dir * 4, other.y - sprite_height/2, par_physics) != noone{
 					scr_enter_hanging()
 				}
 			}

--- a/scripts/scr_mouse_set_throw_dir/scr_mouse_set_throw_dir.gml
+++ b/scripts/scr_mouse_set_throw_dir/scr_mouse_set_throw_dir.gml
@@ -56,5 +56,4 @@ if not has_gun{
 	//Add on extra vspeed to compensate for x_distance
 	var gravity_incr = 0.4
 	vspeed -= (x_distance / max(abs(hspeed), 3)) * (gravity_incr / 2)
-	show_debug_message("No gun")
 }

--- a/scripts/scr_mouse_set_throw_dir/scr_mouse_set_throw_dir.gml
+++ b/scripts/scr_mouse_set_throw_dir/scr_mouse_set_throw_dir.gml
@@ -44,8 +44,8 @@ if slope < min_slope{
 }
 						
 //Normalize the slope from -1 to 1
-vspeed = ((strength*5 / mass) + logn(max_slope, slope) * (strength*5 / mass)) * dirY
-hspeed = (2*(strength*5 / mass) - abs(vspeed)) * dirX 
+vspeed = ((strength*4 / mass) + logn(max_slope, slope) * (strength*4 / mass)) * dirY
+hspeed = (2*(strength*4 / mass) - abs(vspeed)) * dirX 
 
 //If the player does not have a gun equipped, improve their aiming
 if not has_gun{

--- a/scripts/scr_set_character_stats/scr_set_character_stats.gml
+++ b/scripts/scr_set_character_stats/scr_set_character_stats.gml
@@ -6,21 +6,11 @@
 //Assign parameters
 var index = argument0
 
-
-/*
-Assignments:
-	grinch - 5
-	yeti - 7
-	reindeer - 9
-	nutcracker - 10
-	santa - 11
-*/
-
 //Give stats
 switch index{
 	
 	//grinch
-	case 5:
+	case spr_grinch:
 		other.gameCharacter.hp = 100
 		other.gameCharacter.hp_max = 100
 		other.gameCharacter.energy = 100
@@ -34,7 +24,7 @@ switch index{
 		break
 	
 	//yeti
-	case 7:
+	case spr_yeti:
 		other.gameCharacter.hp = 120
 		other.gameCharacter.hp_max = 120
 		other.gameCharacter.energy = 90
@@ -48,7 +38,7 @@ switch index{
 		break
 	
 	//reindeer
-	case 9:
+	case spr_reindeer:
 		other.gameCharacter.hp = 80
 		other.gameCharacter.hp_max = 80
 		other.gameCharacter.energy = 95
@@ -62,7 +52,7 @@ switch index{
 		break
 	
 	//nutcracker
-	case 10:
+	case spr_nutcracker:
 		other.gameCharacter.hp = 100
 		other.gameCharacter.hp_max = 100
 		other.gameCharacter.energy = 105
@@ -76,7 +66,7 @@ switch index{
 		break
 		
 	//santa
-	case 11:
+	case spr_santa:
 		other.gameCharacter.hp = 95
 		other.gameCharacter.hp_max = 95
 		other.gameCharacter.energy = 115

--- a/scripts/scr_throw_using_gamepad/scr_throw_using_gamepad.gml
+++ b/scripts/scr_throw_using_gamepad/scr_throw_using_gamepad.gml
@@ -31,8 +31,8 @@ if slope < min_slope{
 }
 						
 //Normalize the slope from -1 to 1
-vspeed = ((strength*5 / mass) + logn(max_slope, slope) * (strength*5 / mass)) * dirY
-hspeed = (2*(strength*5 / mass) - abs(vspeed)) * dirX 
+vspeed = ((strength*4 / mass) + logn(max_slope, slope) * (strength*4 / mass)) * dirY
+hspeed = (2*(strength*4 / mass) - abs(vspeed)) * dirX 
 
 //If the player does not have a gun equipped, improve their aiming
 if not has_gun{

--- a/scripts/scr_throw_using_keyboard/scr_throw_using_keyboard.gml
+++ b/scripts/scr_throw_using_keyboard/scr_throw_using_keyboard.gml
@@ -30,8 +30,8 @@ else{
 }
 
 //Normalize the slope
-vspeed = (dcos(angle) * (strength*5 / mass)*2) * dirY
-hspeed = (2*(strength*5 / mass) - abs(vspeed)) * dirX
+vspeed = (dcos(angle) * (strength*4 / mass)*2) * dirY
+hspeed = (2*(strength*4 / mass) - abs(vspeed)) * dirX
 
 //If the player does not have a gun equipped, improve their aiming
 if not has_gun{


### PR DESCRIPTION
## Number of Issue Fixed
- #154 #218 #217 #219 

### Changes Proposed in the Pull Request:
__Fixed a bug causing players to lose left and right movement after climbing__
- Players can also move left or right while holding down on the fire or ice key now

__Climbing changes__
- Players can now climb up and down even with a sentry nearby
- Players can climb up and down while holding an object
- Players can now climb up ledges with a pushable object on top, pushing it out of the way
- Fixed a glitch involving climbing down a block to the side of you instead of under you

__Player changes__
- Players can reach a ledge equally high with or without an object in their hands (unless the player is very weak or the object is very heavy)
- Decreased the multiplier for throw strength from 5 to 4 (20% decrease). Players of normal strength now throw fireballs, iceballs, items, etc. a max of 3 blocks.

__Changed mass of `obj_ball` to be the same as other items__

### Known Problems
- none

### Notes for Reviewer
- none
